### PR TITLE
Feat: Implement prompt erasing bofore post

### DIFF
--- a/src/services/sora_client.py
+++ b/src/services/sora_client.py
@@ -250,7 +250,7 @@ class SoraClient:
                     "kind": "sora"
                 }
             ],
-            "post_text": prompt
+            "post_text": ""
         }
 
         # 发布请求需要添加 sentinel token


### PR DESCRIPTION
Removed the post_text parameter from src.services.sora_client.SoraClient.post-video_for-watermark_free.
避免prompt过长导致发布时报错。