### PR TITLE
feat: 支持多 Client ID 刷新机制

### DIFF
--- a/config/setting.toml
+++ b/config/setting.toml
@@ -44,3 +44,5 @@ custom_parse_token = ""
 
 [token_refresh]
 at_auto_refresh_enabled = false
+# RT 刷新使用的 Client ID 列表（逗号分隔，依次尝试，成功后自动绑定）
+client_ids = "app_LlGpXReQgckcGGUo2JrYvtJK,app_WXrF1LSkiTtfYqiL6XtjygvX"

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,7 +1,7 @@
 """Configuration management"""
 import tomli
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 
 class Config:
     """Application configuration"""
@@ -207,6 +207,12 @@ class Config:
         if "token_refresh" not in self._config:
             self._config["token_refresh"] = {}
         self._config["token_refresh"]["at_auto_refresh_enabled"] = enabled
+
+    @property
+    def refresh_client_ids(self) -> List[str]:
+        """获取用于刷新的 client_id 列表（逗号分隔）"""
+        client_ids_str = self._config.get("token_refresh", {}).get("client_ids", "app_LlGpXReQgckcGGUo2JrYvtJK")
+        return [cid.strip() for cid in client_ids_str.split(",") if cid.strip()]
 
 # Global config instance
 config = Config()

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -194,6 +194,7 @@ class Database:
                     ("video_enabled", "BOOLEAN DEFAULT 1"),
                     ("image_concurrency", "INTEGER DEFAULT -1"),
                     ("video_concurrency", "INTEGER DEFAULT -1"),
+                    ("client_id", "TEXT"),
                 ]
 
                 for col_name, col_type in columns_to_add:
@@ -274,7 +275,8 @@ class Database:
                     image_enabled BOOLEAN DEFAULT 1,
                     video_enabled BOOLEAN DEFAULT 1,
                     image_concurrency INTEGER DEFAULT -1,
-                    video_concurrency INTEGER DEFAULT -1
+                    video_concurrency INTEGER DEFAULT -1,
+                    client_id TEXT
                 )
             """)
 
@@ -549,8 +551,8 @@ class Database:
                 INSERT INTO tokens (token, email, username, name, st, rt, remark, expiry_time, is_active,
                                    plan_type, plan_title, subscription_end, sora2_supported, sora2_invite_code,
                                    sora2_redeemed_count, sora2_total_count, sora2_remaining_count, sora2_cooldown_until,
-                                   image_enabled, video_enabled, image_concurrency, video_concurrency)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                   image_enabled, video_enabled, image_concurrency, video_concurrency, client_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (token.token, token.email, "", token.name, token.st, token.rt,
                   token.remark, token.expiry_time, token.is_active,
                   token.plan_type, token.plan_title, token.subscription_end,
@@ -558,7 +560,7 @@ class Database:
                   token.sora2_redeemed_count, token.sora2_total_count,
                   token.sora2_remaining_count, token.sora2_cooldown_until,
                   token.image_enabled, token.video_enabled,
-                  token.image_concurrency, token.video_concurrency))
+                  token.image_concurrency, token.video_concurrency, token.client_id))
             await db.commit()
             token_id = cursor.lastrowid
 
@@ -694,8 +696,9 @@ class Database:
                           image_enabled: Optional[bool] = None,
                           video_enabled: Optional[bool] = None,
                           image_concurrency: Optional[int] = None,
-                          video_concurrency: Optional[int] = None):
-        """Update token (AT, ST, RT, remark, expiry_time, subscription info, image_enabled, video_enabled)"""
+                          video_concurrency: Optional[int] = None,
+                          client_id: Optional[str] = None):
+        """Update token (AT, ST, RT, remark, expiry_time, subscription info, image_enabled, video_enabled, client_id)"""
         async with aiosqlite.connect(self.db_path) as db:
             # Build dynamic update query
             updates = []
@@ -748,6 +751,10 @@ class Database:
             if video_concurrency is not None:
                 updates.append("video_concurrency = ?")
                 params.append(video_concurrency)
+
+            if client_id is not None:
+                updates.append("client_id = ?")
+                params.append(client_id)
 
             if updates:
                 params.append(token_id)

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -36,6 +36,8 @@ class Token(BaseModel):
     # 并发限制
     image_concurrency: int = -1  # 图片并发数限制，-1表示不限制
     video_concurrency: int = -1  # 视频并发数限制，-1表示不限制
+    # 刷新配置
+    client_id: Optional[str] = None  # 记录刷新使用的 client_id
 
 class TokenStats(BaseModel):
     """Token statistics"""


### PR DESCRIPTION
- 添加 client_ids 配置项支持多个客户端ID
- 实现自动依次尝试多个 client_id 进行 RT 刷新
- 刷新成功后自动记录并绑定 client_id，后续刷新优先使用已成功的 client_id
- 更新数据库模型添加 client_id 字段

主要获取的RT可以来自多个clientId，需要支持不同的clientId，买的几个账号需要别的clientId 
